### PR TITLE
Added dashboard sharing settings delay

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func (p *Processor) Process() error {
 			}
 
 			if endpointName == "Dashboards" {
+				time.Sleep(10 * time.Second)
 				if p.Config.Verbose {
 					log.Println("Sending sharing data")
 				}


### PR DESCRIPTION
Dashboard share settings was executing too quickly therefore the cluster was returning dashboard not found - added delay.